### PR TITLE
Added closest available "facts" to met data box

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -432,6 +432,7 @@ contains (DEFINES, QGC_ENABLE_PAIRING) {
 HEADERS += \
     src/QmlControls/CustomAction.h \
     src/QmlControls/CustomActionManager.h \
+    src/QmlControls/MetFactValueGrid.h \
     src/QmlControls/QmlUnitsConversion.h \
     src/Vehicle/VehicleEscStatusFactGroup.h \
     src/api/QGCCorePlugin.h \
@@ -447,6 +448,7 @@ contains (DEFINES, QGC_ENABLE_PAIRING) {
 
 SOURCES += \
     src/QmlControls/CustomActionManager.cc \
+    src/QmlControls/MetFactValueGrid.cc \
     src/Vehicle/VehicleEscStatusFactGroup.cc \
     src/api/QGCCorePlugin.cc \
     src/api/QGCOptions.cc \

--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -19,7 +19,7 @@
         <file alias="TelemetryRSSIIndicator.qml">src/ui/toolbar/TelemetryRSSIIndicator.qml</file>
         <file alias="VTOLModeIndicator.qml">src/ui/toolbar/VTOLModeIndicator.qml</file>
         <file alias="APMSupportForwardingIndicator.qml">src/ui/toolbar/APMSupportForwardingIndicator.qml</file>
-            </qresource>
+    </qresource>
     <qresource prefix="/checklists">
         <file alias="DefaultChecklist.qml">src/FlightDisplay/DefaultChecklist.qml</file>
         <file alias="MultiRotorChecklist.qml">src/FlightDisplay/MultiRotorChecklist.qml</file>
@@ -291,6 +291,7 @@
         <file alias="VTOLLandingPatternEditor.qml">src/PlanView/VTOLLandingPatternEditor.qml</file>
         <file alias="QGroundControl/Controls/MockLinkOptionsDlg.qml">src/comm/MockLinkOptionsDlg.qml</file>
         <file alias="QGroundControl/FlightDisplay/FlyViewInsetViewer.qml">src/FlightDisplay/FlyViewInsetViewer.qml</file>
+        <file alias="QGroundControl/Controls/MetFactValueGrid.qml">src/QmlControls/MetFactValueGrid.qml</file>
     </qresource>
     <qresource prefix="/FirstRunPromptDialogs">
         <file alias="UnitsFirstRunPrompt.qml">src/FirstRunPromptDialogs/UnitsFirstRunPrompt.qml</file>

--- a/src/FlightDisplay/FlyViewWidgetLayer.qml
+++ b/src/FlightDisplay/FlyViewWidgetLayer.qml
@@ -246,6 +246,8 @@ Item {
     MetDataWindow {
         id:                 metDataWindow
         x:                  recalcXPosition()
+
+        anchors.bottom: parent.bottom
         anchors.margins:    _toolsMargin
         visible:            _guidedController._metDataVisible
 
@@ -254,18 +256,7 @@ Item {
 
 
         function recalcXPosition() {
-            // First try centered
-            var halfRootWidth   = _root.width / 2
-            var halfPanelWidth  = metDataWindow.width / 2
-            var leftX           = (halfRootWidth - halfPanelWidth) - _toolsMargin
-            var rightX          = (halfRootWidth + halfPanelWidth) + _toolsMargin
-            if (leftX >= parentToolInsets.leftEdgeBottomInset || rightX <= parentToolInsets.rightEdgeBottomInset ) {
-                // It will fit in the horizontalCenter
-                return halfRootWidth - halfPanelWidth
-            } else {
-                // Anchor to left edge
-                return parentToolInsets.leftEdgeBottomInset + _toolsMargin
-            }
+            return parentToolInsets.leftEdgeBottomInset + _toolsMargin
         }
     }
 

--- a/src/FlightDisplay/MetDataWindow.qml
+++ b/src/FlightDisplay/MetDataWindow.qml
@@ -34,4 +34,16 @@ Rectangle {
         anchors.top: parent.top
         anchors.horizontalCenter: parent.horizontalCenter
     }
+
+    Rectangle {
+        color: qgcPal.window
+        width: parent.width
+        height: 250
+        anchors.bottom: parent.bottom
+        MetFactValueGrid {
+            id:                     valueArea
+            defaultSettingsGroup:   metDataDefaultSettingsGroup
+            anchors.fill: parent
+        }
+    }
 }

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -70,6 +70,7 @@
 #include "MAVLinkInspectorController.h"
 #endif
 #include "HorizontalFactValueGrid.h"
+#include "MetFactValueGrid.h"
 #include "InstrumentValueData.h"
 #include "AppMessages.h"
 #include "SimulatedPosition.h"
@@ -501,6 +502,7 @@ void QGCApplication::_initCommon()
 
     qmlRegisterUncreatableType<FactValueGrid>       (kQGCTemplates,                         1, 0, "FactValueGrid",              kRefOnly);
     qmlRegisterType<HorizontalFactValueGrid>        (kQGCTemplates,                         1, 0, "HorizontalFactValueGrid");
+    qmlRegisterType<MetFactValueGrid>               (kQGCTemplates,                         1, 0, "MetFactValueGrid");
 
     qmlRegisterType<QGCMapCircle>                   ("QGroundControl.FlightMap",            1, 0, "QGCMapCircle");
 

--- a/src/QmlControls/MetFactValueGrid.cc
+++ b/src/QmlControls/MetFactValueGrid.cc
@@ -1,0 +1,29 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "MetFactValueGrid.h"
+#include "InstrumentValueData.h"
+#include "QGCApplication.h"
+#include "QGCCorePlugin.h"
+
+#include <QSettings>
+
+const QString MetFactValueGrid::metDataDefaultSettingsGroup ("MetDataDefaultSettings");
+
+MetFactValueGrid::MetFactValueGrid(QQuickItem* parent)
+    : FactValueGrid(parent)
+{
+
+}
+
+MetFactValueGrid::MetFactValueGrid(const QString& defaultSettingsGroup)
+    : FactValueGrid(defaultSettingsGroup)
+{
+
+}

--- a/src/QmlControls/MetFactValueGrid.h
+++ b/src/QmlControls/MetFactValueGrid.h
@@ -1,0 +1,35 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include "FactSystem.h"
+#include "QmlObjectListModel.h"
+#include "QGCApplication.h"
+#include "FactValueGrid.h"
+
+class InstrumentValueData;
+
+class MetFactValueGrid : public FactValueGrid
+{
+    Q_OBJECT
+
+public:
+    MetFactValueGrid(QQuickItem *parent = nullptr);
+    MetFactValueGrid(const QString& defaultSettingsGroup);
+
+    Q_PROPERTY(QString metDataDefaultSettingsGroup MEMBER metDataDefaultSettingsGroup CONSTANT)
+
+    static const QString metDataDefaultSettingsGroup;
+
+private:
+    Q_DISABLE_COPY(MetFactValueGrid)
+};
+
+QML_DECLARE_TYPE(MetFactValueGrid)

--- a/src/QmlControls/MetFactValueGrid.qml
+++ b/src/QmlControls/MetFactValueGrid.qml
@@ -1,0 +1,108 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick          2.12
+import QtQuick.Layouts  1.2
+import QtQuick.Controls 2.5
+import QtQml            2.12
+
+import QGroundControl.Templates     1.0 as T
+import QGroundControl.Controls      1.0
+import QGroundControl.ScreenTools   1.0
+import QGroundControl.Controllers   1.0
+import QGroundControl.Palette       1.0
+import QGroundControl.FlightMap     1.0
+import QGroundControl               1.0
+
+T.MetFactValueGrid {
+    id:                     _root
+    Layout.preferredWidth:  topLayout.width
+    Layout.preferredHeight: topLayout.height
+
+    property real   _margins:               ScreenTools.defaultFontPixelWidth / 2
+    property int    _rowMax:                2
+
+    QGCPalette { id: qgcPal; colorGroupEnabled: enabled }
+
+    ColumnLayout {
+        id:         topLayout
+        spacing:    0
+
+        RowLayout {
+            RowLayout {
+                id:         labelValueColumnLayout
+                spacing:    ScreenTools.defaultFontPixelWidth * 1.25
+
+                Repeater {
+                    model: _root.columns
+
+                    GridLayout {
+                        rows:           object.count
+                        columns:        2
+                        rowSpacing:     0
+                        columnSpacing:  ScreenTools.defaultFontPixelWidth / 4
+                        flow:           GridLayout.TopToBottom
+
+                        Repeater {
+                            id:     labelRepeater
+                            model:  object
+
+                            InstrumentValueLabel {
+                                Layout.fillHeight:      true
+                                Layout.alignment:       Qt.AlignRight
+                                instrumentValueData:    object
+                            }
+                        }
+
+                        Repeater {
+                            id:     valueRepeater
+                            model:  object
+
+                            property real   _index:     index
+                            property real   maxWidth:   0
+                            property var    lastCheck:  new Date().getTime()
+
+                            function recalcWidth() {
+                                var newMaxWidth = 0
+                                for (var i=0; i<valueRepeater.count; i++) {
+                                    newMaxWidth = Math.max(newMaxWidth, valueRepeater.itemAt(i).contentWidth)
+                                }
+                                maxWidth = Math.min(maxWidth, newMaxWidth)
+                            }
+
+                            InstrumentValueValue {
+                                Layout.fillHeight:      true
+                                Layout.alignment:       Qt.AlignLeft
+                                Layout.preferredWidth:  valueRepeater.maxWidth
+                                instrumentValueData:    object
+
+                                property real lastContentWidth
+
+                                Component.onCompleted:  {
+                                    valueRepeater.maxWidth = Math.max(valueRepeater.maxWidth, contentWidth)
+                                    lastContentWidth = contentWidth
+                                }
+
+                                onContentWidthChanged: {
+                                    valueRepeater.maxWidth = Math.max(valueRepeater.maxWidth, contentWidth)
+                                    lastContentWidth = contentWidth
+                                    var currentTime = new Date().getTime()
+                                    if (currentTime - valueRepeater.lastCheck > 30 * 1000) {
+                                        valueRepeater.lastCheck = currentTime
+                                        valueRepeater.recalcWidth()
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/QmlControls/QGroundControl/Controls/qmldir
+++ b/src/QmlControls/QGroundControl/Controls/qmldir
@@ -37,6 +37,7 @@ FlightModeMenuIndicator                 1.0 FlightModeMenuIndicator.qml
 MainToolBar                             1.0 MainToolBar.qml
 MainWindowSavedState                    1.0 MainWindowSavedState.qml
 MAVLinkMessageButton                    1.0 MAVLinkMessageButton.qml
+MetFactValueGrid                        1.0 MetFactValueGrid.qml
 MissionCommandDialog                    1.0 MissionCommandDialog.qml
 MissionItemEditor                       1.0 MissionItemEditor.qml
 MissionItemIndexLabel                   1.0 MissionItemIndexLabel.qml

--- a/src/api/QGCCorePlugin.cc
+++ b/src/api/QGCCorePlugin.cc
@@ -10,6 +10,7 @@
 #include "QGCApplication.h"
 #include "QGCCorePlugin.h"
 #include "QGCOptions.h"
+#include "MetFactValueGrid.h"
 #include "QmlComponentInfo.h"
 #include "FactMetaData.h"
 #include "SettingsManager.h"
@@ -22,11 +23,12 @@
 #endif
 #include "QGCLoggingCategory.h"
 #include "QGCCameraManager.h"
-#include "HorizontalFactValueGrid.h"
+#include "FactValueGrid.h"
 #include "InstrumentValueData.h"
 
 #include <QtQml>
 #include <QQmlEngine>
+#include <QDebug>
 
 /// @file
 ///     @brief Core Plugin Interface for QGroundControl - Default Implementation
@@ -291,80 +293,124 @@ QString QGCCorePlugin::showAdvancedUIMessage() const
 
 void QGCCorePlugin::factValueGridCreateDefaultSettings(const QString& defaultSettingsGroup)
 {
-    HorizontalFactValueGrid factValueGrid(defaultSettingsGroup);
+    qDebug() << "Got to factValueGridCreateDefaultSettings!";
+    FactValueGrid factValueGrid(defaultSettingsGroup);
 
     bool        includeFWValues = factValueGrid.vehicleClass() == QGCMAVLink::VehicleClassFixedWing || factValueGrid.vehicleClass() == QGCMAVLink::VehicleClassVTOL || factValueGrid.vehicleClass() == QGCMAVLink::VehicleClassAirship;
+    qDebug() << "Showing default settings group:";
+    qDebug() << defaultSettingsGroup;
+    qDebug() << "MetFactValueGrid::metDataDefaultSettingsGroup:";
+    qDebug() << MetFactValueGrid::metDataDefaultSettingsGroup;
+    if(defaultSettingsGroup == MetFactValueGrid::metDataDefaultSettingsGroup) {
+        factValueGrid.setFontSize(FactValueGrid::MediumFontSize);
 
-    factValueGrid.setFontSize(FactValueGrid::LargeFontSize);
-
-    factValueGrid.appendColumn();
-    factValueGrid.appendColumn();
-    factValueGrid.appendColumn();
-    if (includeFWValues) {
         factValueGrid.appendColumn();
-    }
-    factValueGrid.appendRow();
+        // need to append row for each item after the first
+        factValueGrid.appendRow();
+        factValueGrid.appendRow();
+        factValueGrid.appendRow();
 
-    int                 rowIndex    = 0;
-    QmlObjectListModel* column      = factValueGrid.columns()->value<QmlObjectListModel*>(0);
+        int                 rowIndex    = 0;
+        QmlObjectListModel* column      = factValueGrid.columns()->value<QmlObjectListModel*>(0);
 
-    InstrumentValueData* value = column->value<InstrumentValueData*>(rowIndex++);
-    value->setFact("Vehicle", "AltitudeRelative");
-    value->setIcon("arrow-thick-up.svg");
-    value->setText(value->fact()->shortDescription());
-    value->setShowUnits(true);
+        InstrumentValueData* value = column->value<InstrumentValueData*>(rowIndex++);
+        value->setFact("Temperature", "temperature1");
+        value->setIcon("");
+        value->setText(value->fact()->shortDescription());
+        value->setShowUnits(true);
 
-    value = column->value<InstrumentValueData*>(rowIndex++);
-    value->setFact("Vehicle", "DistanceToHome");
-    value->setIcon("bookmark copy 3.svg");
-    value->setText(value->fact()->shortDescription());
-    value->setShowUnits(true);
-
-    rowIndex    = 0;
-    column      = factValueGrid.columns()->value<QmlObjectListModel*>(1);
-
-    value = column->value<InstrumentValueData*>(rowIndex++);
-    value->setFact("Vehicle", "ClimbRate");
-    value->setIcon("arrow-simple-up.svg");
-    value->setText(value->fact()->shortDescription());
-    value->setShowUnits(true);
-
-    value = column->value<InstrumentValueData*>(rowIndex++);
-    value->setFact("Vehicle", "GroundSpeed");
-    value->setIcon("arrow-simple-right.svg");
-    value->setText(value->fact()->shortDescription());
-    value->setShowUnits(true);
+        value = column->value<InstrumentValueData*>(rowIndex++);
+        value->setFact("Hygrometer", "Humidity");
+        value->setIcon("");
+        value->setText(value->fact()->shortDescription());
+        value->setShowUnits(true);
 
 
-    if (includeFWValues) {
+        value = column->value<InstrumentValueData*>(rowIndex++);
+        value->setFact("Wind", "speed");
+        // value->setIcon("");
+        value->setText(value->fact()->shortDescription());
+        value->setShowUnits(true);
+
+
+        value = column->value<InstrumentValueData*>(rowIndex++);
+        value->setFact("Wind", "Direction");
+        // value->setIcon("");
+        value->setText(value->fact()->shortDescription());
+        value->setShowUnits(true);
+
+    } else {
+        factValueGrid.setFontSize(FactValueGrid::LargeFontSize);
+
+        factValueGrid.appendColumn();
+        factValueGrid.appendColumn();
+        factValueGrid.appendColumn();
+        if (includeFWValues) {
+            factValueGrid.appendColumn();
+        }
+        factValueGrid.appendRow();
+
+        int                 rowIndex    = 0;
+        QmlObjectListModel* column      = factValueGrid.columns()->value<QmlObjectListModel*>(0);
+
+        InstrumentValueData* value = column->value<InstrumentValueData*>(rowIndex++);
+        value->setFact("Vehicle", "AltitudeRelative");
+        value->setIcon("arrow-thick-up.svg");
+        value->setText(value->fact()->shortDescription());
+        value->setShowUnits(true);
+
+        value = column->value<InstrumentValueData*>(rowIndex++);
+        value->setFact("Vehicle", "DistanceToHome");
+        value->setIcon("bookmark copy 3.svg");
+        value->setText(value->fact()->shortDescription());
+        value->setShowUnits(true);
+
         rowIndex    = 0;
-        column      = factValueGrid.columns()->value<QmlObjectListModel*>(2);
+        column      = factValueGrid.columns()->value<QmlObjectListModel*>(1);
 
         value = column->value<InstrumentValueData*>(rowIndex++);
-        value->setFact("Vehicle", "AirSpeed");
-        value->setText("AirSpd");
+        value->setFact("Vehicle", "ClimbRate");
+        value->setIcon("arrow-simple-up.svg");
+        value->setText(value->fact()->shortDescription());
         value->setShowUnits(true);
 
         value = column->value<InstrumentValueData*>(rowIndex++);
-        value->setFact("Vehicle", "ThrottlePct");
-        value->setText("Thr");
+        value->setFact("Vehicle", "GroundSpeed");
+        value->setIcon("arrow-simple-right.svg");
+        value->setText(value->fact()->shortDescription());
+        value->setShowUnits(true);
+
+
+        if (includeFWValues) {
+            rowIndex    = 0;
+            column      = factValueGrid.columns()->value<QmlObjectListModel*>(2);
+
+            value = column->value<InstrumentValueData*>(rowIndex++);
+            value->setFact("Vehicle", "AirSpeed");
+            value->setText("AirSpd");
+            value->setShowUnits(true);
+
+            value = column->value<InstrumentValueData*>(rowIndex++);
+            value->setFact("Vehicle", "ThrottlePct");
+            value->setText("Thr");
+            value->setShowUnits(true);
+        }
+
+        rowIndex    = 0;
+        column      = factValueGrid.columns()->value<QmlObjectListModel*>(includeFWValues ? 3 : 2);
+
+        value = column->value<InstrumentValueData*>(rowIndex++);
+        value->setFact("Vehicle", "FlightTime");
+        value->setIcon("timer.svg");
+        value->setText(value->fact()->shortDescription());
+        value->setShowUnits(false);
+
+        value = column->value<InstrumentValueData*>(rowIndex++);
+        value->setFact("Vehicle", "FlightDistance");
+        value->setIcon("travel-walk.svg");
+        value->setText(value->fact()->shortDescription());
         value->setShowUnits(true);
     }
-
-    rowIndex    = 0;
-    column      = factValueGrid.columns()->value<QmlObjectListModel*>(includeFWValues ? 3 : 2);
-
-    value = column->value<InstrumentValueData*>(rowIndex++);
-    value->setFact("Vehicle", "FlightTime");
-    value->setIcon("timer.svg");
-    value->setText(value->fact()->shortDescription());
-    value->setShowUnits(false);
-
-    value = column->value<InstrumentValueData*>(rowIndex++);
-    value->setFact("Vehicle", "FlightDistance");
-    value->setIcon("travel-walk.svg");
-    value->setText(value->fact()->shortDescription());
-    value->setShowUnits(true);
 }
 
 QQmlApplicationEngine* QGCCorePlugin::createQmlApplicationEngine(QObject* parent)


### PR DESCRIPTION
Added some Met-related "facts" to the met data box, but they are likely not the correct ones. We will need to get the real mavlink data fields from Nathan and replace the existing ones. Other future work includes fixing up the UI, and possibly simplifying the implementation of the facts on this box. We may be able to go so far as to go directly to using the InstrumentValueData and eliminate the MetFactValueGrid and the changes to the QGCCorePlugin.