### PR TITLE
Fix Release Build

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -456,8 +456,7 @@ HEADERS += \
     src/api/QGCOptions.h \
     src/api/QGCSettings.h \
     src/api/QmlComponentInfo.h \
-    src/GPS/Drivers/src/base_station.h \
-    src/qgcunittest/NetCdfTest.h
+    src/GPS/Drivers/src/base_station.h
 
 contains (DEFINES, QGC_ENABLE_PAIRING) {
     HEADERS += \
@@ -475,8 +474,7 @@ SOURCES += \
     src/api/QGCCorePlugin.cc \
     src/api/QGCOptions.cc \
     src/api/QGCSettings.cc \
-    src/api/QmlComponentInfo.cc \
-    src/qgcunittest/NetCdfTest.cc
+    src/api/QmlComponentInfo.cc
 
 contains (DEFINES, QGC_ENABLE_PAIRING) {
     SOURCES += \
@@ -541,6 +539,7 @@ DebugBuild { PX4FirmwarePlugin { PX4FirmwarePluginFactory { APMFirmwarePlugin { 
         #src/qgcunittest/FileManagerTest.h \
         #src/qgcunittest/MainWindowTest.h \
         #src/qgcunittest/MessageBoxTest.h \
+        src/qgcunittest/NetCdfTest.h
 
     SOURCES += \
         src/Audio/AudioOutputTest.cc \
@@ -591,6 +590,7 @@ DebugBuild { PX4FirmwarePlugin { PX4FirmwarePluginFactory { APMFirmwarePlugin { 
         #src/qgcunittest/FileManagerTest.cc \
         #src/qgcunittest/MainWindowTest.cc \
         #src/qgcunittest/MessageBoxTest.cc \
+        src/qgcunittest/NetCdfTest.cc
 
 } } } } } }
 


### PR DESCRIPTION
Fixed .pro file to include netcdf unit tests only during a debug build, thus fixing errors for other build types.