### PR TITLE
All changes from herelink for now

### DIFF
--- a/src/Joystick/JoystickManager.cc
+++ b/src/Joystick/JoystickManager.cc
@@ -66,6 +66,7 @@ void JoystickManager::init() {
     connect(this, &JoystickManager::updateAvailableJoysticksSignal, this, &JoystickManager::restartJoystickCheckTimer);
 #endif
     connect(&_joystickCheckTimer, &QTimer::timeout, this, &JoystickManager::_updateAvailableJoysticks);
+    _updateAvailableJoysticks();
     _joystickCheckTimerCounter = 5;
     _joystickCheckTimer.start(1000);
 }

--- a/src/Settings/FlyView.SettingsGroup.json
+++ b/src/Settings/FlyView.SettingsGroup.json
@@ -27,7 +27,8 @@
     "name":             "alternateInstrumentPanel",
     "shortDesc": "Use Vertical Instrument Panel instead of the default one",
     "type":             "bool",
-    "default":     false
+    "default":     false,
+    "rebootRequired": true
 },
 {
     "name":             "showAdditionalIndicatorsCompass",

--- a/src/Settings/Video.SettingsGroup.json
+++ b/src/Settings/Video.SettingsGroup.json
@@ -138,6 +138,13 @@
     "enumValues":       "0,1,2,3,4,5",
     "default":           0,
     "qgcRebootRequired": true
+},
+{
+    "name":             "cameraId",
+    "shortDesc":        "Camera ID",
+    "longDesc":         "Camera ID used for video streaming.",
+    "type":             "uint32",
+    "default":          0
 }
 ]
 }

--- a/src/VideoManager/VideoManager.cc
+++ b/src/VideoManager/VideoManager.cc
@@ -82,6 +82,8 @@ VideoManager::~VideoManager()
         }
 #endif
     }
+
+    delete _videoStreamControl;
 }
 
 //-----------------------------------------------------------------------------
@@ -104,6 +106,10 @@ VideoManager::setToolbox(QGCToolbox *toolbox)
    connect(_videoSettings->lowLatencyMode(),&Fact::rawValueChanged, this, &VideoManager::_lowLatencyModeChanged);
    MultiVehicleManager *pVehicleMgr = qgcApp()->toolbox()->multiVehicleManager();
    connect(pVehicleMgr, &MultiVehicleManager::activeVehicleChanged, this, &VideoManager::_setActiveVehicle);
+
+   // Create video stream control, for Herelink specific functions, and link it to _restartAllVideos, to restart when HDMI source changes
+   _videoStreamControl = new VideoStreamControl();
+   connect(_videoStreamControl, &VideoStreamControl::videoNeedsReset, this, &VideoManager::_restartAllVideos);
 
 #if defined(QGC_GST_STREAMING)
     GStreamer::blacklist(static_cast<VideoSettings::VideoDecoderOptions>(_videoSettings->forceVideoDecoder()->rawValue().toInt()));
@@ -818,9 +824,9 @@ VideoManager::_restartVideo(unsigned id)
 
     if (_videoStarted[id]) {
         _stopReceiver(id);
-    } else {
-        _startReceiver(id);
     }
+
+    _startReceiver(id);
 #endif
 }
 
@@ -841,7 +847,7 @@ VideoManager::_startReceiver(unsigned id)
     const unsigned rtsptimeout = _videoSettings->rtspTimeout()->rawValue().toUInt();
     /* The gstreamer rtsp source will switch to tcp if udp is not available after 5 seconds.
        So we should allow for some negotiation time for rtsp */
-    const unsigned timeout = (source == VideoSettings::videoSourceRTSP ? rtsptimeout : 2 );
+    const unsigned timeout = (source == VideoSettings::videoSourceRTSP ? rtsptimeout : 15 );
 
     if (id > 1) {
         qCDebug(VideoManagerLog) << "Unsupported receiver id" << id;

--- a/src/VideoManager/VideoManager.h
+++ b/src/VideoManager/VideoManager.h
@@ -21,6 +21,7 @@
 #include "VideoReceiver.h"
 #include "QGCToolbox.h"
 #include "SubtitleWriter.h"
+#include "VideoStreamControl.h"
 
 Q_DECLARE_LOGGING_CATEGORY(VideoManagerLog)
 
@@ -56,6 +57,8 @@ public:
     Q_PROPERTY(bool             decoding                READ    decoding                                    NOTIFY decodingChanged)
     Q_PROPERTY(bool             recording               READ    recording                                   NOTIFY recordingChanged)
     Q_PROPERTY(QSize            videoSize               READ    videoSize                                   NOTIFY videoSizeChanged)
+    // Specific to Herelink only, to manage HDMI switching
+    Q_PROPERTY(VideoStreamControl* videoStreamControl   READ    videoStreamControl                          CONSTANT)
 
     virtual bool        hasVideo            ();
     virtual bool        isGStreamer         ();
@@ -87,6 +90,8 @@ public:
         const quint32 size = _videoSize;
         return QSize((size >> 16) & 0xFFFF, size & 0xFFFF);
     }
+
+    VideoStreamControl* videoStreamControl () { return _videoStreamControl; } // herelink
 
 // FIXME: AV: they should be removed after finishing multiple video stream support
 // new arcitecture does not assume direct access to video receiver from QML side, even if it works for now
@@ -176,6 +181,8 @@ protected:
     QString                 _uvcVideoSourceID;
     bool                    _fullScreen             = false;
     Vehicle*                _activeVehicle          = nullptr;
+
+    VideoStreamControl*     _videoStreamControl     = nullptr; // herelink
 };
 
 #endif


### PR DESCRIPTION
Ported most changes from qgroundcontrol-herelink as determined by a dif made between qgroundcontrol-herelink 6a32da015044036a40c4ac08024bfeda25dc3eef and qgroundcontrol 495a17b4964d3ed90f241388b3a02a35e96c9663. That qgroundcontrol was the last common ancestor between qgc Stable_V4.4 and qgc-herelink Stable_V4.4.3-herelink. Changes from QGroundControlQmlGlobal.cc and QML files were not ported.


